### PR TITLE
refactor: Separate general initializations outside of the gui modules

### DIFF
--- a/src/dfacto/__init__.py
+++ b/src/dfacto/__init__.py
@@ -11,37 +11,75 @@ Requires Python >= 3.8
 Usage:
     ''python -m dfacto''
 """
-__all__ = ["run_main"]
+
+__all__ = ["IS_FROZEN", "DEV_MODE", "run_main"]
 
 import logging
-import multiprocessing
+import os
 import sys
+from typing import Final
 
-from dfacto.frontend import guimain as gui
+from dfacto.util.logutil import LogConfig
+
+logger = logging.getLogger(__name__)
+
+log_config: LogConfig
+
+IS_FROZEN: Final[bool] = getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")
+DEV_MODE: Final[bool] = os.environ.get("DFACTO_DEV", "0") != "0"
 
 
 def except_hook(exc_type, exc_value, _exc_traceback):  # type: ignore[no-untyped-def]
     error_msg = f"{exc_type.__name__}: {exc_value}"
-    logger = logging.getLogger(__name__)
     logger.fatal("%s", error_msg, exc_info=False)
     sys.stderr.write(f"\ndfacto - {str(error_msg)}\n\n")
-    # for p in multiprocessing.active_children():
-    #     p.terminate()
+    logger.info("Dfacto is closing...")
+    log_config.stop_logging()
     sys.exit(1)
 
 
 def run_main() -> None:
-    """Program entry point.
+    """Program entry point."""
+    global log_config  # pylint: disable=global-statement
 
-    Handles exceptions not trapped earlier.
-    """
+    # Handles exceptions not trapped earlier.
     sys.excepthook = except_hook
-    sys.exit(gui.qt_main())
-    # except Exception as e:
-    #     logger = logging.getLogger(__name__)
-    #     logger.fatal("Fatal error!", exc_info=True)
-    #     sys.stderr.write(f"\ndfacto - {str(e)}\n\n")
-    #     sys.exit(1)
+
+    # Load settings and initialize the dfacto_settings singleton instance.
+    from dfacto.settings import (  # pylint: disable=import-outside-toplevel
+        dfacto_settings,
+    )
+
+    # Initialize and start the log server.
+    log_config = LogConfig(
+        dfacto_settings.app_dirs.user_log_dir / "dfacto.log",
+        dfacto_settings.log_level,
+        log_on_console=True,
+    )
+    log_config.init_logging()
+
+    logger.info("Dfacto is starting...")
+
+    # Log the running mode for information.
+    if IS_FROZEN:
+        logger.info("Running in a PyInstaller bundle")
+    else:
+        logger.info("Running in a normal Python process")
+    if DEV_MODE:
+        logger.info("Running in Development mode")
+    else:
+        logger.info("Running in Production mode")
+
+    # Import the main UI (it will import backend modules) and launch it.
+    from dfacto.frontend import guimain  # pylint: disable=import-outside-toplevel
+
+    ret = guimain.qt_main()
+
+    logger.info("Dfacto is closing...")
+    # Stop the log server.
+    log_config.stop_logging()
+
+    sys.exit(ret)
 
 
 if __name__ == "__main__":

--- a/src/dfacto/backend/naming.py
+++ b/src/dfacto/backend/naming.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2023 Eric Lemoine
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import json
 import logging
 from dataclasses import dataclass, field
@@ -460,7 +466,10 @@ class NamingTemplates:
             with self._templates_file.open() as fh:
                 templates = json.load(fh, cls=NamingTemplateDecoder)
                 return templates["invoice"], templates["destination"]
-        except (FileNotFoundError, json.JSONDecodeError) as e:
+        except FileNotFoundError:
+            logger.info("No custom naming templates found: using defaults")
+            return {}, {}
+        except json.JSONDecodeError as e:
             logger.warning("Cannot load custom naming templates: %s", e)
             return {}, {}
 

--- a/src/dfacto/frontend/guimain.py
+++ b/src/dfacto/frontend/guimain.py
@@ -27,7 +27,6 @@ from dfacto.backend.api.command import CommandStatus
 
 # Util
 from dfacto.util import qtutil as QtUtil
-from dfacto.util.logutil import LogConfig
 from dfacto.util.settings import SettingsError
 
 # Views
@@ -65,10 +64,7 @@ class QtMainView(QtWidgets.QMainWindow):
             the parent QMainWindow.
 
     Attributes:
-        _sourceManager: reference to the images' sources manager.
-        _splash: reference to the splash screen to show the main view initialization
-            progress.
-        _status: reference to the Main window status bar.
+        company_profile: reference to the selected company profile.
     """
 
     def __init__(
@@ -629,16 +625,6 @@ def qt_main() -> int:
     settings = Config.dfacto_settings
     resources = settings.resources
 
-    # Initialize and start the log server.
-    log_config = LogConfig(
-        settings.app_dirs.user_log_dir / "dfacto.log",
-        settings.log_level,
-        log_on_console=True,
-    )
-    log_config.init_logging()
-
-    logger.info("Dfacto is starting...")
-
     # QT_SCALE_FACTOR environment variable allow to zoom the HMI for better.
     # readability
     if "QT_SCALE_FACTOR" not in os.environ:
@@ -661,8 +647,6 @@ def qt_main() -> int:
     company_profile, is_new = _select_company_profile()
     if company_profile is None:
         logger.info(f"No company profile is selected: Dfacto is closing...")
-        # Stop the log server.
-        log_config.stop_logging()
         return 1
 
     logger.info("Connecting to database...")
@@ -679,8 +663,6 @@ def qt_main() -> int:
             f"Cannot create the {company_profile.name} company profile\n\nReason is:\n{response.reason}",
             QtWidgets.QMessageBox.StandardButton.Close,
         )
-        # Stop the log server.
-        log_config.stop_logging()
         return 1
     logger.info(f"Connected to {company_profile.home / 'dfacto.db'}")
     logger.info(f"Company profile {company_profile.name} is selected")
@@ -700,10 +682,6 @@ def qt_main() -> int:
 
     # Start the Qt main loop.
     app.exec()
-
-    logger.info("Dfacto is closing...")
-    # Stop the log server.
-    log_config.stop_logging()
 
     return 0
 

--- a/src/dfacto/settings.py
+++ b/src/dfacto/settings.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2023 Eric Lemoine
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 """The DfactoSettings model.
 
 The DfactoSettings model defines the dfacto application settings and make them
@@ -5,14 +11,12 @@ accessible throughout the application by exposing a dfacto_settings instance.
 """
 
 import logging
-import os
-import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from dfacto import DEV_MODE, IS_FROZEN
 from dfacto.backend import naming
-from dfacto.util import settings
-from dfacto.util.settings import Setting
+from dfacto.util.settings import Setting, Settings, get_app_dirs
 
 if TYPE_CHECKING:
     from dfacto.util.settings import WinAppDirs
@@ -22,41 +26,32 @@ __all__ = ["dfacto_settings"]
 logger = logging.getLogger(__name__)
 
 
-def is_frozen() -> bool:
-    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
-        print("running in a PyInstaller bundle")
-        logger.info("Running in a PyInstaller bundle")
-        return True
-    print("running in a normal Python process")
-    logger.info("Running in a normal Python process")
-    return False
-
-
-class DfactoSettings(settings.Settings):
+class DfactoSettings(Settings):
     """The DfactoSettings model definition.
 
     The DfactoSettings model is a specialization of the Settings singleton base
     class. It declares:
-        a set of Setting descriptor corresponding to the Fotocop application
+        a set of Setting descriptor corresponding to the Dfacto application
             settings,
 
     Class attributes:
-        lastSource: key and info (kind, id, path and subDirs) on the last opened
-            images' source.
-        lastDestination: path to the last selected images' destination.
-        lastImageNamingTemplate: key of the last selected images' naming template.
-        lastDestinationNamingTemplate: key of the last selected images' destination
+        last_profile: name of the last opened company profile.
+        profiles: a mapping of profile names to profiles descripion already created.
+        lastInvoiceNamingTemplate: key of the last selected invoice naming template.
+        lastDestinationNamingTemplate: key of the last selected invoice' destination
             naming template.
-        lastNamingExtension: the last selected images' extension format.
-        log_level: The global Fotocop application log level.
-        window_position: the last Fotocop application windows top left corner.
-        window_size: the last Fotocop application windows size.
-        qt_scale_factor: A magnifying factor to increase the Fotocop application
+        default_company_folder: Path to the default folder where to find or store
+            company profiles.
+        due_date_delta: delay before to remind a not paid invoice (in days).
+        log_level: The global Dfacto application log level.
+        window_position: the last Dfacto application windows top left corner.
+        window_size: the last Dfacto application windows size.
+        qt_scale_factor: A magnifying factor to increase the Dfacto application
             lisibility
+        font_size: The base font size to use in the Dfacto application.
 
     Attributes:
-        appDirs: A WinAppDirs NamedTuple containing the user app
-            directories paths.
+        appDirs: A WinAppDirs NamedTuple containing the user app directories paths.
         resources: Path to the UI resources directory (images, icons,..).
         templates: Path to the Jinja templates directory.
     """
@@ -67,33 +62,33 @@ class DfactoSettings(settings.Settings):
 
     _DEFAULT_LOGLEVEL = "DEBUG"
 
-    last_profile: Setting = settings.Setting(default_value=None)
-    profiles: Setting = settings.Setting(default_value=None)
-    lastInvoiceNamingTemplate: Setting = settings.Setting(
+    last_profile: Setting = Setting(default_value=None)
+    profiles: Setting = Setting(default_value=None)
+    lastInvoiceNamingTemplate: Setting = Setting(
         default_value=naming.NamingTemplates.default_invoice_naming_template
     )
-    lastDestinationNamingTemplate: Setting = settings.Setting(
+    lastDestinationNamingTemplate: Setting = Setting(
         default_value=naming.NamingTemplates.default_destination_naming_template
     )
-    # default_company_folder = settings.Setting(
+    # default_company_folder = Setting(
     # default_value="C:/Users/T0018179/MyApp/Git/home/portable/DFacto"
     # )
-    default_company_folder = settings.Setting(default_value="F:/Users/Documents/Dfacto")
-    due_date_delta = settings.Setting(default_value=30)
-    log_level: Setting = settings.Setting(default_value=_DEFAULT_LOGLEVEL)
-    window_position: Setting = settings.Setting(default_value=(0, 0))
-    window_size: Setting = settings.Setting(default_value=(1600, 800))
-    qt_scale_factor: Setting = settings.Setting(default_value="1.0")
-    font_size: Setting = settings.Setting(default_value=2)
+    default_company_folder = Setting(default_value="F:/Users/Documents/Dfacto")
+    due_date_delta = Setting(default_value=30)
+    log_level: Setting = Setting(default_value=_DEFAULT_LOGLEVEL)
+    window_position: Setting = Setting(default_value=(0, 0))
+    window_size: Setting = Setting(default_value=(1600, 800))
+    qt_scale_factor: Setting = Setting(default_value="1.0")
+    font_size: Setting = Setting(default_value=2)
 
     def __init__(self, app_name: str) -> None:
         # Retrieve or create the user directories for the application.
-        app_dirs = settings.get_app_dirs(app_name)
+        app_dirs = get_app_dirs(app_name)
 
         super().__init__(app_dirs.user_data_dir / "settings")
 
         self.app_dirs = app_dirs
-        if is_frozen():
+        if IS_FROZEN:
             self.resources = Path(__file__).resolve().parent.parent / "resources"
         else:
             self.resources = Path(__file__).resolve().parent.parent.parent / "resources"
@@ -119,7 +114,7 @@ class DfactoSettings(settings.Settings):
             setattr(self, setting, default_value)
 
 
-if os.environ.get("DFACTO_DEV", 0):
+if DEV_MODE:
     dfacto_settings = DfactoSettings("dfacto_dev")
 else:
     dfacto_settings = DfactoSettings("dfacto")


### PR DESCRIPTION
The Dfacto package init:
* configure and start the LogServer
* set a global hook to properly trap and log uncatched exception
* compute and publidh running mode (frozen mode, dev mode)
* load the Dfacto settings
before starting the Dfacto Frontend (Qt GUI main loop).